### PR TITLE
feat(render): add MyST admonition callouts

### DIFF
--- a/packages/myst-awesome/src/layouts/BasePage.astro
+++ b/packages/myst-awesome/src/layouts/BasePage.astro
@@ -825,6 +825,7 @@ import MystContentStyles from '../components/MystContentStyles.astro';
   import '@awesome.me/webawesome/dist/components/button/button.js';
   import '@awesome.me/webawesome/dist/components/drawer/drawer.js';
   import '@awesome.me/webawesome/dist/components/icon/icon.js';
+  import '@awesome.me/webawesome/dist/components/callout/callout.js';
 
   // renderMystAst
   import '@awesome.me/webawesome/dist/components/tooltip/tooltip.js';

--- a/packages/myst-awesome/src/pages/admonition-test.astro
+++ b/packages/myst-awesome/src/pages/admonition-test.astro
@@ -1,0 +1,106 @@
+---
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2025 Fideus Labs LLC
+
+import Layout from '../layouts/Layout.astro';
+import { renderMystAst } from '../lib/render-myst-ast.js';
+
+const testAst = {
+  type: 'root',
+  children: [
+    {
+      type: 'heading',
+      depth: 1,
+      children: [{ type: 'text', value: 'Admonition Rendering Test' }],
+    },
+    {
+      type: 'paragraph',
+      children: [
+        {
+          type: 'text',
+          value: 'This page validates MyST admonition rendering with titles.',
+        },
+      ],
+    },
+    {
+      type: 'admonition',
+      kind: 'note',
+      children: [
+        {
+          type: 'admonitionTitle',
+          children: [{ type: 'text', value: 'Custom Note Title' }],
+        },
+        {
+          type: 'paragraph',
+          children: [
+            {
+              type: 'text',
+              value: 'This is a note admonition with a custom title.',
+            },
+          ],
+        },
+      ],
+    },
+    {
+      type: 'admonition',
+      kind: 'warning',
+      children: [
+        {
+          type: 'paragraph',
+          children: [
+            {
+              type: 'text',
+              value: 'This warning has no explicit title node.',
+            },
+          ],
+        },
+      ],
+    },
+    {
+      type: 'admonition',
+      kind: 'danger',
+      class: ['simple'],
+      children: [
+        {
+          type: 'admonitionTitle',
+          children: [{ type: 'text', value: 'Simple Danger' }],
+        },
+        {
+          type: 'paragraph',
+          children: [
+            {
+              type: 'text',
+              value: 'This simple admonition renders without an icon slot.',
+            },
+          ],
+        },
+      ],
+    },
+  ],
+};
+
+const renderedContent = await renderMystAst(testAst as any);
+---
+
+<Layout title="Admonition Rendering Test">
+  <main class="container">
+    <div class="content" set:html={renderedContent} />
+  </main>
+</Layout>
+
+<style>
+  .container {
+    max-width: 800px;
+    margin: 0 auto;
+    padding: 2rem;
+  }
+
+  .content :global(wa-callout) {
+    margin-bottom: var(--wa-space-m, 1rem);
+  }
+
+  :global(.admonition-title) {
+    display: block;
+    margin-bottom: var(--wa-space-2xs, 0.25rem);
+  }
+</style>

--- a/packages/myst-awesome/tests/admonition-rendering.spec.ts
+++ b/packages/myst-awesome/tests/admonition-rendering.spec.ts
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: MIT
+// SPDX-FileCopyrightText: 2025 Fideus Labs LLC
+
+import { test, expect } from "@playwright/test";
+
+test.describe("Admonition Rendering", () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto("http://localhost:4322/admonition-test");
+    await page.waitForLoadState("networkidle");
+  });
+
+  test("renders custom title for admonitionTitle", async ({ page }) => {
+    const title = page.locator("wa-callout .admonition-title").first();
+    await expect(title).toContainText("Custom Note Title");
+  });
+
+  test("maps note admonition to brand variant", async ({ page }) => {
+    const callout = page.locator("wa-callout").first();
+    await expect(callout).toHaveAttribute("variant", "brand");
+  });
+
+  test("defaults warning title when missing", async ({ page }) => {
+    const warningCallout = page.locator("wa-callout").nth(1);
+    const title = warningCallout.locator(".admonition-title");
+    await expect(title).toContainText("Warning");
+  });
+
+  test("simple admonition omits icon slot", async ({ page }) => {
+    const dangerCallout = page.locator("wa-callout").nth(2);
+    const iconSlot = dangerCallout.locator("wa-icon[slot=\"icon\"]");
+    await expect(iconSlot).toHaveCount(0);
+  });
+});


### PR DESCRIPTION
## Summary
- Add MyST `admonition` and `admonitionTitle` rendering to the MyST AST renderer, mapping kinds to Web Awesome `wa-callout` variants and icons
- Register the Web Awesome callout component globally and add a fixture page to exercise admonition behavior
- Add Playwright coverage for title rendering, variant mapping, and icon suppression for `simple` admonitions

## Why
- The theme previously ignored MyST admonition nodes, so admonition directives rendered as plain content instead of styled callouts
- This change aligns MyST admonitions with Web Awesome callout design and enables accurate titles via `admonitionTitle`

## Implementation details
- `render-myst-ast.ts` now builds callouts with title fallback logic (explicit title → `admonitionTitle` → heading/strong → kind)
- Admonition kinds map to `wa-callout` variants and icons (e.g., warning/danger) with optional icon suppression for `simple`
- Added `admonition-test.astro` fixture and `admonition-rendering.spec.ts` Playwright tests