### PR TITLE
feat(render): log and skip MyST comment nodes

### DIFF
--- a/packages/myst-awesome/src/lib/render-myst-ast.ts
+++ b/packages/myst-awesome/src/lib/render-myst-ast.ts
@@ -69,6 +69,12 @@ export async function renderMystAst(root: Root): Promise<string> {
       }
       case "text":
         return (node as any).value || "";
+      case "comment": {
+        const commentNode = node as any;
+        const commentValue = commentNode.value ?? commentNode.raw ?? "";
+        console.log("MyST comment:", commentValue || commentNode);
+        return "";
+      }
       case "break":
         return "<br />";
       case "emphasis": {

--- a/packages/myst-awesome/src/pages/admonition-test.astro
+++ b/packages/myst-awesome/src/pages/admonition-test.astro
@@ -23,6 +23,8 @@ This page tests all MyST admonition types and features.
 
 ## Basic Admonition Kinds
 
+% This is a MyST comment that should be logged but not rendered.
+
 ### Note Admonition
 
 \`\`\`{note}


### PR DESCRIPTION
## Summary
- Add renderer handling for MyST comment nodes, logging their content and omitting them from HTML output.
- Include a MyST comment in the admonition test page to verify logging behavior.

## Why
- MyST comments are authoring metadata and should not render in the final HTML, but logging them helps confirm parsing during development.

## Implementation details
- `renderMystAst` now handles the `comment` node type, logs the node value (or raw node), and returns an empty string.
- `packages/myst-awesome/src/pages/admonition-test.astro` includes a sample `%` comment line for validation.